### PR TITLE
remove reverend in favor of path-to-regexp.compile

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var path = require('path')
 var fs = require('fs')
-var reverend = require('reverend')
+var path2regexp = require('path-to-regexp')
 var mkdirp = require('mkdirp')
 var once = require('once')
 
@@ -8,7 +8,7 @@ module.exports = function (route, renderer) {
   return function (pages) {
     var promises = pages.map(function (page) {
       return new Promise(function (resolve, reject) {
-        var file = reverend(route, page)
+        var file = path2regexp.compile(route)(page)
         var directory = path.dirname(file)
         var mkdirPromise, done, result
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "mkdirp": "^0.5.0",
     "once": "^1.3.1",
-    "reverend": "^0.3.0"
+    "path-to-regexp": "^1.1.1"
   },
   "devDependencies": {
     "istanbul": "^0.3.13",


### PR DESCRIPTION
[Path-to-regexp](https://github.com/pillarjs/path-to-regexp), which powers [Reverend](https://github.com/krakenjs/reverend), has recently added the [ability to reverse routes](https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp), rendering `Reverend` unnecessary. As such, `Reverend` is in the process of being deprecated.

The sole differences between the implementation in `Reverend` and that of `path-to-regexp` is a bit of duck-typing to prevent throws. This small amount of duck-typing can be seen in the [shim](http://github.com/krakenjs/reverend/blob/shim/index.js) branch.
